### PR TITLE
Allow Transport to be set on the client and fix access token assignment bug

### DIFF
--- a/medium.go
+++ b/medium.go
@@ -147,6 +147,7 @@ type Medium struct {
 	AccessToken       string
 	Host              string
 	Timeout           time.Duration
+	Transport         http.RoundTripper
 	fs                fileOpener
 }
 
@@ -157,6 +158,7 @@ func NewClient(id, secret string) *Medium {
 		ApplicationSecret: secret,
 		Host:              host,
 		Timeout:           defaultTimeout,
+		Transport:         http.DefaultTransport,
 		fs:                osFS{},
 	}
 }
@@ -342,7 +344,7 @@ func (m *Medium) request(cr clientRequest, result interface{}) error {
 
 	// Create the HTTP client
 	client := &http.Client{
-		Transport: http.DefaultTransport,
+		Transport: m.Transport,
 		Timeout:   m.Timeout,
 	}
 
@@ -386,7 +388,7 @@ func (m *Medium) acquireAccessToken(v url.Values) (AccessToken, error) {
 	err := m.request(cr, &at)
 
 	// Set the access token on the service.
-	if err != nil {
+	if err == nil {
 		m.AccessToken = at.AccessToken
 	}
 	return at, err


### PR DESCRIPTION
+ On App Engine, one cannot use `http.DefaultTransport` but has to use `urlfetch.Transport` with a given context: https://godoc.org/google.golang.org/appengine/urlfetch#Transport. Allow for any transport that satisfies the `http.RoundTripper` interface to be used by the client.
+ Upon successfully acquiring an access token, the client was incorrectly checking for a non-nil error in order to assign the token to the client per the documentation.